### PR TITLE
Optimization: reduced database calls and improved memory usage

### DIFF
--- a/classes/events.php
+++ b/classes/events.php
@@ -132,14 +132,20 @@ class events {
         $userid = $event->relateduserid;
         $courseid = $event->courseid;
         self::course_user_cache_updated($courseid, $userid);
-        $records = $DB->get_records('course_completion_criteria', ['courseinstance' => $courseid]);
-        if ($records) {
-            foreach ($records as $record) {
-                if ($record) {
-                    self::course_user_cache_updated($record->course, $userid);
-                }
-            }
+        
+        $recordrs = $DB->get_recordset_sql(
+            <<<'EOT'
+            SELECT DISTINCT course
+            FROM {course_completion_criteria}
+            WHERE
+                courseinstance = ?
+            EOT,
+            [ $courseid ]
+        );
+        foreach ($recordrs as $record) {
+            self::course_user_cache_updated($record->course, $userid);
         }
+        $recordrs->close();
     }
 
     /**

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -1175,6 +1175,7 @@ class renderer extends \core_courseformat\output\section_renderer {
         // (AFTER any icons). Otherwise it was displayed before.
         $cmtext = '';
         $videotime = $mod->modname == 'videotime';
+        $videoinstance = null;
         $isvideotimelabel = false;
         $useactivityimagestatus = false;
         $useactivityimage = '';
@@ -1195,8 +1196,8 @@ class renderer extends \core_courseformat\output\section_renderer {
         if (!empty($url) && !$videotime) {
             $cmtext = $mod->get_formatted_content(['overflowdiv' => true, 'noclean' => true]);
             if (isset($videotime) && $videotime) {
-                $videotime = $DB->get_record('videotime', ['id' => $mod->instance]);
-                $cmtext = $videotime->intro;
+                $videoinstance = $DB->get_record('videotime', ['id' => $mod->instance]);
+                $cmtext = $videoinstance->intro;
             }
             $cmtextcontent = format_string($cmtext);
             $cmtextlength = get_config('format_designer', 'activitydesclength');
@@ -1258,7 +1259,9 @@ class renderer extends \core_courseformat\output\section_renderer {
         $videotimeduration = '';
         $durationformatted = '';
         if ($mod->modname == 'videotime') {
-            $videoinstance = $DB->get_record('videotime', ['id' => $mod->instance]);
+            if ($videoinstance === null) {
+                $videoinstance = $DB->get_record('videotime', ['id' => $mod->instance]);
+            }
             $dbman = $DB->get_manager();
             if ($videoinstance && $dbman->table_exists('videotime_vimeo_video')) {
                 if ($video = $DB->get_record('videotime_vimeo_video', ['link' => $videoinstance->vimeo_url])) {
@@ -1354,8 +1357,7 @@ class renderer extends \core_courseformat\output\section_renderer {
     public function get_activity_elementclasses($mod) {
 
         $option  = \format_designer\options::get_option($mod->id, 'activityelements');
-        if (!empty($option)) {
-            $element = json_decode($option, true);
+        if ($option) {
             $classes = [
                 0 => 'content-hide', 1 => 'content-show', 2 => 'content-show-hover',
                 3 => 'content-hide-hover', 4 => 'content-remove',
@@ -1363,7 +1365,7 @@ class renderer extends \core_courseformat\output\section_renderer {
 
             $elementclasses = array_map(function($v) use ($classes) {
                 return (isset($classes[$v])) ? $classes[$v] : $v;
-            }, $element);
+            }, $option);
             return $elementclasses;
         }
         return [];

--- a/tests/options_test.php
+++ b/tests/options_test.php
@@ -71,15 +71,7 @@ final class options_test extends \advanced_testcase {
      * @covers \format_designer\options::is_json
      */
     public function test_optionisjson(): void {
-        $elements = [
-            'icon' => 2, 'visits' => 1, 'calltoaction' => 2,
-            'title' => 1, 'description' => 2, 'modname' => 3, 'completionbadge' => 3,
-        ];
-        $module = $this->getDataGenerator()->create_module('page', ['course' => $this->course, 'section' => 1,
-            'name' => 'Test page', 'content' => 'Test the module element avilabilities are available',
-            'designer_activityelements' => $elements,
-        ]);
-        $option = \format_designer\options::get_option($module->cmid, 'activityelements');
+        $option = json_encode([ 'a' => 1 ]);
         $isjson = \format_designer\options::is_json($option);
         $this->assertTrue($isjson);
 
@@ -107,7 +99,7 @@ final class options_test extends \advanced_testcase {
         $this->assertEquals($elements, json_decode($field, true));
 
         $option = \format_designer\options::get_option($module->cmid, 'activityelements');
-        $this->assertEquals($elements, json_decode($option, true));
+        $this->assertEquals($elements, $option);
 
         $classes = $PAGE->get_renderer('format_designer')->get_activity_elementclasses((object)['id' => $module->cmid]);
         $this->assertEquals('content-show-hover', $classes['icon']);


### PR DESCRIPTION
## Reduced Database Calls

### Key Optimizations:

* Introduced a static variable in [`format_designer\options::get_options`](https://github.com/E-learningTouch/moodle-format_designer/blob/4c090953ac0f7dba2f3643823d8c63b4a13cfcca/classes/options.php#L68) to cache options for each course module.
* Modified `format_designer\options::get_option` to use the cached result from [`get_options`](https://github.com/E-learningTouch/moodle-format_designer/blob/4c090953ac0f7dba2f3643823d8c63b4a13cfcca/classes/options.php#L56) instead of triggering new database queries.

These changes significantly reduce the number of database calls, especially in courses with a large number of modules or sections.

### Performance Impact (30 course modules)

* **Before optimization:** Over 800 database calls, load time > 20 seconds.
* **After optimization:** Only 30 database calls, load time < 1 second.

## Improved Memory Usage

* Replaced several `get_records` calls with `get_recordset`, particularly in operations involving sections and **videotime** modules, to reduce memory consumption.
* Incorporated filtering logic directly into SQL queries, minimizing the need for additional processing or follow-up queries in PHP.